### PR TITLE
v4.8.1 — the send button is readable when the workspace is dark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The version in `plugins/vstack/.claude-plugin/plugin.json` is what your host
 compares against to decide an update is available. See the release checklist in
 [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+## 4.8.1 — 2026-08-05
+
+- **The comment composer's send button is readable in dark mode.** Its label was
+  fixed to white while its background follows `--ink`, which is the text colour
+  and therefore near-white under a dark theme. The button rendered as a blank
+  white box, at a contrast of 1.12:1. The label now follows `--surface`, the
+  pairing the rest of the interface already uses, giving 15.70:1 in dark and
+  leaving light mode exactly as it was.
+
 ## 4.8.0 — 2026-08-04
 
 - **The plugin declares a version.** Until now it shipped without one, so every

--- a/plugins/vstack/.claude-plugin/plugin.json
+++ b/plugins/vstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vstack",
   "displayName": "Visual Stack",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Stop prompting. Start pointing. Visual Stack adds a Figma-like feedback layer to Claude Code. Create a new screen from a prompt, screenshot, reference site, or design system, or open an app you already have running. Click any element and leave feedback exactly where the problem is hiding, and Claude publishes the next revision into the same workspace. Compare revisions on a timeline, preview desktop, tablet, and mobile layouts, and keep every comment attached to the element, route, and version it refers to. Wireframes are self-contained HTML and review state stays in your project.",
   "author": {
     "name": "Cavalry Collective",

--- a/plugins/vstack/.codex-plugin/plugin.json
+++ b/plugins/vstack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vstack",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Stop prompting. Start pointing. Visual Stack adds a Figma-like feedback layer to Codex. Create a new screen from a prompt, screenshot, reference site, or design system, or open an app you already have running. Click any element and leave feedback exactly where the problem is hiding, and Codex publishes the next revision into the same workspace. Compare revisions on a timeline, preview desktop, tablet, and mobile layouts, and keep every comment attached to the element, route, and version it refers to. Wireframes are self-contained HTML and review state stays in your project.",
   "author": {
     "name": "Cavalry Collective",

--- a/plugins/vstack/skills/review/assets/workspace.html
+++ b/plugins/vstack/skills/review/assets/workspace.html
@@ -562,7 +562,9 @@ body.phase #hiNew{display:inline-flex}
 #composer .cfoot{display:flex;align-items:center;gap:5px;padding:8px 9px;margin-top:8px;
   border-top:1px solid var(--line);background:var(--paper)}
 #composer .cfoot .hint{flex:1;font-size:11px;color:var(--ink-3)}
-#composer .csave{height:26px;padding:0 11px;border-radius:6px;background:var(--ink);color:#fff;
+/* --surface, not white: --ink is the text colour, so it inverts with the theme
+   and a fixed white label disappears into the button in dark mode. */
+#composer .csave{height:26px;padding:0 11px;border-radius:6px;background:var(--ink);color:var(--surface);
   font-weight:600;font-size:11.5px;flex:none}
 #composer .csave:hover{filter:brightness(1.25)}
 #composer .csave .kbd{font:500 9.5px/1 var(--mono);opacity:.6;margin-left:4px}


### PR DESCRIPTION

- **The comment composer's send button is readable in dark mode.** Its label was
  fixed to white while its background follows `--ink`, which is the text colour
  and therefore near-white under a dark theme. The button rendered as a blank
  white box, at a contrast of 1.12:1. The label now follows `--surface`, the
  pairing the rest of the interface already uses, giving 15.70:1 in dark and
  leaving light mode exactly as it was.
Contrast on the button label, measured from the token values in `tokens.css`:

| Theme | Before (`#fff`) | After (`var(--surface)`) |
|---|---|---|
| Light | 17.90:1 | 17.90:1 — unchanged |
| Dark | 1.12:1 | 15.70:1 |

Not verified visually — the Chrome extension was disconnected. The numbers come from the real token values, not from a render.

---

Release PR for 4.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)